### PR TITLE
docs: Update incorrect API path in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Libraries can be found in the [Releases](https://github.com/OmniOneID/did-blockc
 
 ## API Reference
 
-You can find the API reference [here](docs/Blockchain_API.md).
+You can find the API reference [here](docs/api/Blockchain_API.md).
 
 ## Contributing
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -73,7 +73,7 @@ did-blockchain-sdk-server
 
 ## API 참조
 
-API 참조는 [여기](docs/Blockchain_API_ko.md)에서 확인할 수 있습니다.
+API 참조는 [여기](docs/api/Blockchain_API_ko.md)에서 확인할 수 있습니다.
 
 ## 기여
 Contributing 및 pull request 제출 절차에 대한 자세한 내용은 [CONTRIBUTING.md](CONTRIBUTING.md)와 [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) 를 참조하세요.


### PR DESCRIPTION
Updated  the incorrect API path in the README.md file from `docs/Blockchain_API.md` to `docs/api/Blockchain_API.md`.